### PR TITLE
specify path for .deb files

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -36,7 +36,7 @@ For the chosen distribution, you will need to download two packages, a library p
 sudo apt update && sudo apt -y install curl
 curl -sLk https://sourceforge.net/projects/regina-rexx/files/regina-rexx/3.9.5/regina-rexx_3.9.5-2_amd64-Debian-11.deb > regina-rexx_3.9.5-2_amd64-Debian-11.deb
 curl -sLk https://sourceforge.net/projects/regina-rexx/files/regina-rexx/3.9.5/libregina3_3.9.5-2_amd64-Debian-11.deb > libregina3_3.9.5-2_amd64-Debian-11.deb
-sudo apt -y install libregina3_3.9.5-2_amd64-Debian-11.deb regina-rexx_3.9.5-2_amd64-Debian-11.deb
+sudo apt -y install ./libregina3_3.9.5-2_amd64-Debian-11.deb ./regina-rexx_3.9.5-2_amd64-Debian-11.deb
 ```
 
 And on CentOS, and RHEL 7, try:


### PR DESCRIPTION
`apt` expects a path, so it can distinguish between a local file and a package from a remote repository.

Our `docs/INSTALLATION.md` instructions for Debian or Ubuntu now specify a path for the locally downloaded files `libregina3_3.9.5-2_amd64-Debian-11.deb` `regina-rexx_3.9.5-2_amd64-Debian-11.deb`, so `apt` understands not to look for these names in remote repositories.
