### PR TITLE
Omit -toplevel.rexx from solution

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,7 +35,6 @@
     ]
   },
   "exercises": {
-    "concept": [],
     "practice": [
       {
         "slug": "hello-world",
@@ -559,7 +558,6 @@
       }
     ]
   },
-  "concepts": [],
   "key_features": [
     {
       "title": "General Purpose",
@@ -593,15 +591,15 @@
     }
   ],
   "tags": [
+    "execution_mode/interpreted",
     "paradigm/imperative",
     "paradigm/procedural",
-    "typing/dynamic",
-    "typing/weak",
-    "execution_mode/interpreted",
-    "runtime/language_specific",
-    "platform/windows",
     "platform/linux",
     "platform/mac",
+    "platform/windows",
+    "runtime/language_specific",
+    "typing/dynamic",
+    "typing/weak",
     "used_for/backends",
     "used_for/cross_platform_development",
     "used_for/scripts"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["accumulate.rexx", "accumulate-toplevel.rexx"],
-    "test": ["test-accumulate"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "accumulate.rexx"
+    ],
+    "test": [
+      "accumulate-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "source": "Conversation with James Edward Gray II",

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["acronym.rexx", "acronym-toplevel.rexx"],
-    "test": ["test-acronym"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "acronym.rexx"
+    ],
+    "test": [
+      "acronym-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Convert a long phrase to its acronym.",
   "source": "Julien Vanier",

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["all-your-base.rexx", "all-your-base-toplevel.rexx"],
-    "test": ["test-all-your-base"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "all-your-base.rexx"
+    ],
+    "test": [
+      "all-your-base-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base."
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["anagram.rexx", "anagram-toplevel.rexx"],
-    "test": ["test-anagram"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "anagram.rexx"
+    ],
+    "test": [
+      "anagram-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "source": "Inspired by the Extreme Startup game",

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["armstrong-numbers.rexx", "armstrong-numbers-toplevel.rexx"],
-    "test": ["test-armstrong-numbers"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "armstrong-numbers.rexx"
+    ],
+    "test": [
+      "armstrong-numbers-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Determine if a number is an Armstrong number.",
   "source": "Wikipedia",

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["atbash-cipher.rexx", "atbash-cipher-toplevel.rexx"],
-    "test": ["test-atbash-cipher"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "atbash-cipher.rexx"
+    ],
+    "test": [
+      "atbash-cipher-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "source": "Wikipedia",

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["bank-account.rexx", "bank-account-toplevel.rexx"],
-    "test": ["test-bank-account"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "bank-account.rexx"
+    ],
+    "test": [
+      "bank-account-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!"
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["beer-song.rexx", "beer-song-toplevel.rexx"],
-    "test": ["test-beer-song"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "beer-song.rexx"
+    ],
+    "test": [
+      "beer-song-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "source": "Learn to Program by Chris Pine",

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["binary-search.rexx", "binary-search-toplevel.rexx"],
-    "test": ["test-binary-search"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "binary-search.rexx"
+    ],
+    "test": [
+      "binary-search-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Implement a binary search algorithm.",
   "source": "Wikipedia",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["bob.rexx", "bob-toplevel.rexx"],
-    "test": ["test-bob"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "bob.rexx"
+    ],
+    "test": [
+      "bob-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["clock.rexx", "clock-toplevel.rexx"],
-    "test": ["test-clock"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "clock.rexx"
+    ],
+    "test": [
+      "clock-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Implement a clock that handles times without dates.",
   "source": "Pairing session with Erin Drummond",

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["collatz-conjecture.rexx", "collatz-conjecture-toplevel.rexx"],
-    "test": ["test-collatz-conjecture"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "collatz-conjecture.rexx"
+    ],
+    "test": [
+      "collatz-conjecture-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture.",
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["custom-set.rexx", "custom-set-toplevel.rexx"],
-    "test": ["test-custom-set"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "custom-set.rexx"
+    ],
+    "test": [
+      "custom-set-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Create a custom set type."
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["darts.rexx", "darts-toplevel.rexx"],
-    "test": ["test-darts"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "darts.rexx"
+    ],
+    "test": [
+      "darts-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["difference-of-squares.rexx", "difference-of-squares-toplevel.rexx"],
-    "test": ["test-difference-of-squares"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "difference-of-squares.rexx"
+    ],
+    "test": [
+      "difference-of-squares-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "source": "Problem 6 at Project Euler",

--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["error-handling.rexx", "error-handling-toplevel.rexx"],
-    "test": ["test-error-handling"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "error-handling.rexx"
+    ],
+    "test": [
+      "error-handling-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Implement various kinds of error handling and resource management."
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["etl.rexx", "etl-toplevel.rexx"],
-    "test": ["test-etl"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "etl.rexx"
+    ],
+    "test": [
+      "etl-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["gigasecond.rexx", "gigasecond-toplevel.rexx"],
-    "test": ["test-gigasecond"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "gigasecond.rexx"
+    ],
+    "test": [
+      "gigasecond-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["grade-school.rexx", "grade-school-toplevel.rexx"],
-    "test": ["test-grade-school"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "grade-school.rexx"
+    ],
+    "test": [
+      "grade-school-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school.",
   "source": "A pairing session with Phil Battos at gSchool"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["grains.rexx", "grains-toplevel.rexx"],
-    "test": ["test-grains"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "grains.rexx"
+    ],
+    "test": [
+      "grains-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "source": "The CodeRanch Cattle Drive, Assignment 6",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["hamming.rexx", "hamming-toplevel.rexx"],
-    "test": ["test-hamming"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "hamming.rexx"
+    ],
+    "test": [
+      "hamming-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "source": "The Calculating Point Mutations problem at Rosalind",

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["hello-world.rexx", "hello-world-toplevel.rexx"],
-    "test": ["test-hello-world"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "hello-world.rexx"
+    ],
+    "test": [
+      "hello-world-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",
   "source": "This is an exercise to introduce users to using Exercism",

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["high-scores.rexx", "high-scores-toplevel.rexx"],
-    "test": ["test-high-scores"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "high-scores.rexx"
+    ],
+    "test": [
+      "high-scores-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Manage a player's High Score list.",
   "source": "Tribute to the eighties' arcade game Frogger"

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["house.rexx", "house-toplevel.rexx"],
-    "test": ["test-house"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "house.rexx"
+    ],
+    "test": [
+      "house-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
   "source": "British nursery rhyme",

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["isbn-verifier.rexx", "isbn-verifier-toplevel.rexx"],
-    "test": ["test-isbn-verifier"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "isbn-verifier.rexx"
+    ],
+    "test": [
+      "isbn-verifier-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Check if a given string is a valid ISBN-10 number.",
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["isogram.rexx", "isogram-toplevel.rexx"],
-    "test": ["test-isogram"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "isogram.rexx"
+    ],
+    "test": [
+      "isogram-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Determine if a word or phrase is an isogram.",
   "source": "Wikipedia",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["leap.rexx", "leap-toplevel.rexx"],
-    "test": ["test-leap"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "leap.rexx"
+    ],
+    "test": [
+      "leap-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a year, report if it is a leap year.",
   "source": "CodeRanch Cattle Drive, Assignment 3",

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["list-ops.rexx", "list-ops-toplevel.rexx"],
-    "test": ["test-list-ops"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "list-ops.rexx"
+    ],
+    "test": [
+      "list-ops-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Implement basic list operations."
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["luhn.rexx", "luhn-toplevel.rexx"],
-    "test": ["test-luhn"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "luhn.rexx"
+    ],
+    "test": [
+      "luhn-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "source": "The Luhn Algorithm on Wikipedia",

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["matching-brackets.rexx", "matching-brackets-toplevel.rexx"],
-    "test": ["test-matching-brackets"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "matching-brackets.rexx"
+    ],
+    "test": [
+      "matching-brackets-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Make sure the brackets and braces all match.",
   "source": "Ginna Baker"

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["matrix.rexx", "matrix-toplevel.rexx"],
-    "test": ["test-matrix"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "matrix.rexx"
+    ],
+    "test": [
+      "matrix-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
   "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["nth-prime.rexx", "nth-prime-toplevel.rexx"],
-    "test": ["test-nth-prime"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "nth-prime.rexx"
+    ],
+    "test": [
+      "nth-prime-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a number n, determine what the nth prime is.",
   "source": "A variation on Problem 7 at Project Euler",

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["nucleotide-count.rexx", "nucleotide-count-toplevel.rexx"],
-    "test": ["test-nucleotide-count"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "nucleotide-count.rexx"
+    ],
+    "test": [
+      "nucleotide-count-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["ocr-numbers.rexx", "ocr-numbers-toplevel.rexx"],
-    "test": ["test-ocr-numbers"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "ocr-numbers.rexx"
+    ],
+    "test": [
+      "ocr-numbers-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
   "source": "Inspired by the Bank OCR kata",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["pangram.rexx", "pangram-toplevel.rexx"],
-    "test": ["test-pangram"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "pangram.rexx"
+    ],
+    "test": [
+      "pangram-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Determine if a sentence is a pangram.",
   "source": "Wikipedia",

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["perfect-numbers.rexx", "perfect-numbers-toplevel.rexx"],
-    "test": ["test-perfect-numbers"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "perfect-numbers.rexx"
+    ],
+    "test": [
+      "perfect-numbers-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["phone-number.rexx", "phone-number-toplevel.rexx"],
-    "test": ["test-phone-number"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "phone-number.rexx"
+    ],
+    "test": [
+      "phone-number-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["prime-factors.rexx", "prime-factors-toplevel.rexx"],
-    "test": ["test-prime-factors"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "prime-factors.rexx"
+    ],
+    "test": [
+      "prime-factors-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Compute the prime factors of a given natural number.",
   "source": "The Prime Factors Kata by Uncle Bob",

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["protein-translation.rexx", "protein-translation-toplevel.rexx"],
-    "test": ["test-protein-translation"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "protein-translation.rexx"
+    ],
+    "test": [
+      "protein-translation-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Translate RNA sequences into proteins.",
   "source": "Tyler Long"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["proverb.rexx", "proverb-toplevel.rexx"],
-    "test": ["test-proverb"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "proverb.rexx"
+    ],
+    "test": [
+      "proverb-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "source": "Wikipedia",

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["queen-attack.rexx", "queen-attack-toplevel.rexx"],
-    "test": ["test-queen-attack"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "queen-attack.rexx"
+    ],
+    "test": [
+      "queen-attack-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "source": "J Dalbey's Programming Practice problems",

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["raindrops.rexx", "raindrops-toplevel.rexx"],
-    "test": ["test-raindrops"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "raindrops.rexx"
+    ],
+    "test": [
+      "raindrops-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["resistor-color-duo.rexx", "resistor-color-duo-toplevel.rexx"],
-    "test": ["test-resistor-color-duo"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "resistor-color-duo.rexx"
+    ],
+    "test": [
+      "resistor-color-duo-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
   "source": "Maud de Vries, Erik Schierboom",

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["resistor-color-trio.rexx", "resistor-color-trio-toplevel.rexx"],
-    "test": ["test-resistor-color-trio"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "resistor-color-trio.rexx"
+    ],
+    "test": [
+      "resistor-color-trio-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
   "source": "Maud de Vries, Erik Schierboom",

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["resistor-color.rexx", "resistor-color-toplevel.rexx"],
-    "test": ["test-resistor-color"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "resistor-color.rexx"
+    ],
+    "test": [
+      "resistor-color-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Convert a resistor band's color to its numeric representation.",
   "source": "Maud de Vries, Erik Schierboom",

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["reverse-string.rexx", "reverse-string-toplevel.rexx"],
-    "test": ["test-reverse-string"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "reverse-string.rexx"
+    ],
+    "test": [
+      "reverse-string-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Reverse a string.",
   "source": "Introductory challenge to reverse an input string",

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["rna-transcription.rexx", "rna-transcription-toplevel.rexx"],
-    "test": ["test-rna-transcription"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "rna-transcription.rexx"
+    ],
+    "test": [
+      "rna-transcription-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "source": "Hyperphysics",

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["roman-numerals.rexx", "roman-numerals-toplevel.rexx"],
-    "test": ["test-roman-numerals"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "roman-numerals.rexx"
+    ],
+    "test": [
+      "roman-numerals-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "source": "The Roman Numeral Kata",

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["rotational-cipher.rexx", "rotational-cipher-toplevel.rexx"],
-    "test": ["test-rotational-cipher"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "rotational-cipher.rexx"
+    ],
+    "test": [
+      "rotational-cipher-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "source": "Wikipedia",

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["saddle-points.rexx", "saddle-points-toplevel.rexx"],
-    "test": ["test-saddle-points"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "saddle-points.rexx"
+    ],
+    "test": [
+      "saddle-points-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Detect saddle points in a matrix.",
   "source": "J Dalbey's Programming Practice problems",

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["scrabble-score.rexx", "scrabble-score-toplevel.rexx"],
-    "test": ["test-scrabble-score"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "scrabble-score.rexx"
+    ],
+    "test": [
+      "scrabble-score-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a word, compute the Scrabble score for that word.",
   "source": "Inspired by the Extreme Startup game",

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["secret-handshake.rexx", "secret-handshake-toplevel.rexx"],
-    "test": ["test-secret-handshake"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "secret-handshake.rexx"
+    ],
+    "test": [
+      "secret-handshake-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "source": "Bert, in Mary Poppins",

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["series.rexx", "series-toplevel.rexx"],
-    "test": ["test-series"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "series.rexx"
+    ],
+    "test": [
+      "series-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "source": "A subset of the Problem 8 at Project Euler",

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["sieve.rexx", "sieve-toplevel.rexx"],
-    "test": ["test-sieve"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "sieve.rexx"
+    ],
+    "test": [
+      "sieve-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "source": "Sieve of Eratosthenes at Wikipedia",

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["simple-cipher.rexx", "simple-cipher-toplevel.rexx"],
-    "test": ["test-simple-cipher"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "simple-cipher.rexx"
+    ],
+    "test": [
+      "simple-cipher-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher.",
   "source": "Substitution Cipher at Wikipedia",

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["space-age.rexx", "space-age-toplevel.rexx"],
-    "test": ["test-space-age"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "space-age.rexx"
+    ],
+    "test": [
+      "space-age-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["square-root.rexx", "square-root-toplevel.rexx"],
-    "test": ["test-square-root"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "square-root.rexx"
+    ],
+    "test": [
+      "square-root-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a natural radicand, return its square root.",
   "source": "wolf99",

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["strain.rexx", "strain-toplevel.rexx"],
-    "test": ["test-strain"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "strain.rexx"
+    ],
+    "test": [
+      "strain-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "source": "Conversation with James Edward Gray II",

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["sublist.rexx", "sublist-toplevel.rexx"],
-    "test": ["test-sublist"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "sublist.rexx"
+    ],
+    "test": [
+      "sublist-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Write a function to determine if a list is a sublist of another list."
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["sum-of-multiples.rexx", "sum-of-multiples-toplevel.rexx"],
-    "test": ["test-sum-of-multiples"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "sum-of-multiples.rexx"
+    ],
+    "test": [
+      "sum-of-multiples-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "source": "A variation on Problem 1 at Project Euler",

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["transpose.rexx", "transpose-toplevel.rexx"],
-    "test": ["test-transpose"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "transpose.rexx"
+    ],
+    "test": [
+      "transpose-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Take input text and output it transposed.",
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["triangle.rexx", "triangle-toplevel.rexx"],
-    "test": ["test-triangle"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "triangle.rexx"
+    ],
+    "test": [
+      "triangle-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "source": "The Ruby Koans triangle project, parts 1 & 2",

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["twelve-days.rexx", "twelve-days-toplevel.rexx"],
-    "test": ["test-twelve-days"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "twelve-days.rexx"
+    ],
+    "test": [
+      "twelve-days-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'.",
   "source": "Wikipedia",

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["two-fer.rexx", "two-fer-toplevel.rexx"],
-    "test": ["test-two-fer"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "two-fer.rexx"
+    ],
+    "test": [
+      "two-fer-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Create a sentence of the form \"One for X, one for me.\".",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ajborla"],
+  "authors": [
+    "ajborla"
+  ],
   "files": {
-    "solution": ["word-count.rexx", "word-count-toplevel.rexx"],
-    "test": ["test-word-count"],
-    "example": [".meta/example.rexx"]
+    "solution": [
+      "word-count.rexx"
+    ],
+    "test": [
+      "word-count-check.rexx"
+    ],
+    "example": [
+      ".meta/example.rexx"
+    ]
   },
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."


### PR DESCRIPTION
Each `.meta/config.json` solution previously mentioned a `...-toplevel.rexx` file.

These are now omitted.

We also update each test entry to show `...-check.rexx`

This change was generated using

```bash
find exercises/practice -name config.json -path  '*/.meta/*' -exec sh -c 'jq ".files.solution = [.files.solution[0]]" "$1" > "$1.tmp" && mv "$1.tmp" "$1"' _ {} \;

find exercises/practice -name config.json -path '*/.meta/*' -exec sh -c 'jq ".files.test = [.files.test[] | sub(\"^test-\"; \"\") + \"-check.rexx\"]" "$1" > "$1.tmp" && mv "$1.tmp" "$1"' _ {} \;

bin/configlet fmt -u
```
